### PR TITLE
REL1_38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v3.0.0
 
-* Make it fully compatible with MediaWiki 1.38 - deal with all deprecated features:
+* Make it fully compatible with MediaWiki 1.38 (and require >= 1.38.0). Deal with all deprecated features:
+  * Use [`$wgOut->disableClientCache()`](https://doc.wikimedia.org/mediawiki-core/master/php/classOutputPage.html#a65494796ef2a9e3cb0864d8c2185fa70) instead of [`$wgOut->enableClientCache(false)`](https://doc.wikimedia.org/mediawiki-core/master/php/classOutputPage.html#a97ca228e1106736ef2b3b988543af448),
   * Use `RequestContext::getMain()->getUser()` instead of `$wgUser`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
@@ -10,7 +11,7 @@
 * Tidy up the code and remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`.
 * According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.
 * Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.
-* Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
+* Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@metalevel.tech>
 
 ## v2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
-* Tidy up the code and remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`.
+* Tidy up the code and:
+  * Remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`,
+  * Replace some short names: `$a` with `$anchor`; `$re` with `$matches`.
 * According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.
 * Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.
 * Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@metalevel.tech>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.0.0
 
-* Make it fully compatible with MediaWiki 1.38 (and require >= 1.38.0). Deal with all deprecated features:
+* Make it fully compatible with MediaWiki 1.38. Deal with all deprecated features:
   * Use [`$wgOut->disableClientCache()`](https://doc.wikimedia.org/mediawiki-core/master/php/classOutputPage.html#a65494796ef2a9e3cb0864d8c2185fa70) instead of [`$wgOut->enableClientCache(false)`](https://doc.wikimedia.org/mediawiki-core/master/php/classOutputPage.html#a97ca228e1106736ef2b3b988543af448),
   * Use `RequestContext::getMain()->getUser()` instead of `$wgUser`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
@@ -12,6 +12,7 @@
 * According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.
 * Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.
 * Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@metalevel.tech>
+* Add backwards compatibility. Already tested with MediaWiki versions [1.35](https://bg.trivictoria.org/wiki/TestPlus), [1.36](https://vectoria.altclavis.com/wiki/TestPlus), [1.38](https://wiki.metalevel.tech/wiki/Embed_Microsoft_MSx_Documents).
 
 ## v2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,39 @@
-#v2.0.2
+# Change log
+
+## v3.0.0
+
+* Make it fully compatible with MediaWiki 1.38 - deal with all deprecated features:
+  * Use `RequestContext::getMain()->getUser()` instead of `$wgUser`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
+* Tidy up the code and remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`.
+* According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.
+* Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.
+* Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
+
+## v2.0.2
+
 * Updated extension.json to support MediaWiki 1.30+.
 
-#v2.0.1
+## v2.0.1
+
 * Switched over to iframes to support newer browsers.
 
-#v2.0.0
+## v2.0.0
+
 * Converted to extension registration.
 * Forcing a max-width: 100%; on the object container.
 
-#v1.1.2
+## v1.1.2
+
 * Added page parameter.
 
-#v1.1.1
+## v1.1.1
+
 * German Translations provided by kghbln <kontakt@wikihoster.net>
 
-#v1.1
+## v1.1
+
 * Fix PHP notices being thrown for some parameters.
 * Missing language string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,37 @@
-#v2.0.2
+# Change log
+
+## v3.0.0
+
+* Make it fully compatible with MediaWiki 1.38 - deal with all deprecated features:
+  * Use `RequestContext::getMain()->getUser()` instead of `$wgUser`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
+* Tidy up rhe code and remove unused function `embedObject()` (note the `embed()` function does this by default).
+* Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
+
+## v2.0.2
+
 * Updated extension.json to support MediaWiki 1.30+.
 
-#v2.0.1
+## v2.0.1
+
 * Switched over to iframes to support newer browsers.
 
-#v2.0.0
+## v2.0.0
+
 * Converted to extension registration.
 * Forcing a max-width: 100%; on the object container.
 
-#v1.1.2
+## v1.1.2
+
 * Added page parameter.
 
-#v1.1.1
+## v1.1.1
+
 * German Translations provided by kghbln <kontakt@wikihoster.net>
 
-#v1.1
+## v1.1
+
 * Fix PHP notices being thrown for some parameters.
 * Missing language string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
-* Tidy up rhe code and remove unused function `embedObject()` (note the `embed()` function does this by default).
+* Tidy up the code and remove unused function `embedObject()` (note the `embed()` function does this by default).
 * Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
 
 ## v2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
-* Tidy up the code and:
+* Tidy up the code, and:
   * Remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`,
   * Replace some short names: `$a` with `$anchor`; `$re` with `$matches`.
 * According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.
 * Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.
 * Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@metalevel.tech>
-* Add backwards compatibility. Already tested with MediaWiki versions [1.35](https://bg.trivictoria.org/wiki/TestPlus), [1.36](https://vectoria.altclavis.com/wiki/TestPlus), [1.38](https://wiki.metalevel.tech/wiki/Embed_Microsoft_MSx_Documents).
+* Add backwards compatibility. Already tested with MediaWiki versions [1.35](https://bg.trivictoria.org/wiki/Test_PDF_Embed), [1.36](https://vectoria.altclavis.com/wiki/Test_PDF_Embed), [1.38](https://wiki.metalevel.tech/wiki/Embed_PDF_Documents).
 
 ## v2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
-* Tidy up the code and remove unused function `embedObject()` (note the `embed()` function does this by default).
+* Tidy up the code and remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`.
+* According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.
+* Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.
 * Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
 
 ## v2.0.2

--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -42,7 +42,7 @@ class PDFEmbed
         global $wgOut;
         $parser->getOutput()->updateCacheExpiry(0);
 
-        if ( method_exists( $wgOut, 'disableClientCache' )) {
+        if (method_exists($wgOut, 'disableClientCache')) {
             $wgOut->disableClientCache();
         } else {
             $wgOut->enableClientCache(false);
@@ -59,11 +59,14 @@ class PDFEmbed
     static public function removeFilePrefix($filename)
     {
         $mwServices = MediaWikiServices::getInstance();
+
         if (method_exists($mwServices, "getContentLanguage")) {
             $contentLang = $mwServices->getContentLanguage();
-            # there are four possible prefixes
+
+            # there are four possible prefixes: 'File' and 'Media' in English and in the wiki's language
             $ns_media_wiki_lang = $contentLang->getFormattedNsText(NS_MEDIA);
             $ns_file_wiki_lang  = $contentLang->getFormattedNsText(NS_FILE);
+
             if (method_exists($mwServices, "getLanguageFactory")) {
                 $langFactory = $mwServices->getLanguageFactory();
                 $lang = $langFactory->getLanguage('en');
@@ -125,11 +128,11 @@ class PDFEmbed
         // so we might reverse some of the parsing again by examining the html
         // whether it contains an anchor <a href= ...
         if (strpos($html, '<a') !== false) {
-            $a = new SimpleXMLElement($html);
+            $anchor = new SimpleXMLElement($html);
             // is there a href element?
-            if (isset($a['href'])) {
+            if (isset($anchor['href'])) {
                 // that's what we want ...
-                $html = $a['href'];
+                $html = $anchor['href'];
             }
         }
 
@@ -168,11 +171,11 @@ class PDFEmbed
 
         # if there are no slashes in the name we assume this
         # might be a pointer to a file
-        if (preg_match('~^([^\/]+\.pdf)(#[0-9]+)?$~', $html, $re)) {
+        if (preg_match('~^([^\/]+\.pdf)(#[0-9]+)?$~', $html, $matches)) {
             # re contains the groups
-            $filename = $re[1];
-            if (count($re) == 3) {
-                $page = $re[2];
+            $filename = $matches[1];
+            if (count($matches) == 3) {
+                $page = $matches[2];
             }
 
             $filename = self::removeFilePrefix($filename);

--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -41,7 +41,12 @@ class PDFEmbed
         // see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/MagicNoCache/+/refs/heads/master/src/MagicNoCacheHooks.php
         global $wgOut;
         $parser->getOutput()->updateCacheExpiry(0);
-        $wgOut->disableClientCache();
+
+        if ( method_exists( $wgOut, 'disableClientCache' )) {
+            $wgOut->disableClientCache();
+        } else {
+            $wgOut->enableClientCache(false);
+        }
     }
 
     /**

--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -249,6 +249,7 @@ class PDFEmbed
         # check the embed mode and return a proper HTML element
         if ($iframe) {
             return Html::rawElement('iframe', [
+                'class' => 'pdf-embed',
                 'width' => $width,
                 'height' => $height,
                 'src' => $pdfSafeUrl,
@@ -257,9 +258,11 @@ class PDFEmbed
         } else {
             # object mode (default)
             return Html::rawElement('object', [
+                'class' => 'pdf-embed',
                 'width' => $width,
                 'height' => $height,
                 'data' => $pdfSafeUrl,
+                'style' => 'max-width: 100%;',
                 'type' => 'application/pdf'
             ], Html::rawElement(
                 'a',

--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -7,9 +7,12 @@
  * @author		Alexia E. Smith
  * @license		LGPLv3 http://opensource.org/licenses/lgpl-3.0.html
  * @package		PDFEmbed
- * @link		http://www.mediawiki.org/wiki/Extension:PDFEmbed
+ * @link		https://www.mediawiki.org/wiki/Extension:PDFEmbed
  *
  **/
+
+use MediaWiki\MediaWikiServices;
+
 class PDFEmbed
 {
 
@@ -38,7 +41,7 @@ class PDFEmbed
         // see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/MagicNoCache/+/refs/heads/master/src/MagicNoCacheHooks.php
         global $wgOut;
         $parser->getOutput()->updateCacheExpiry(0);
-        $wgOut->enableClientCache(false);
+        $wgOut->disableClientCache();
     }
 
     /**
@@ -50,22 +53,22 @@ class PDFEmbed
      */
     static public function removeFilePrefix($filename)
     {
-				$mwservices=MediaWiki\MediaWikiServices::getInstance();
-        if (method_exists($mwservices,"getContentLanguage")) {
-        	$contentLang=$mwservices->getContentLanguage();
-        	# there are four possible prefixes
-        	$ns_media_wiki_lang = $contentLang->getFormattedNsText(NS_MEDIA);
-        	$ns_file_wiki_lang  = $contentLang->getFormattedNsText(NS_FILE);
-        	if (method_exists($mwservices,"getLanguageFactory")) {
-						$langFactory=$mwservices->getLanguageFactory();
-          	$lang=$langFactory->getLanguage('en');
-        		$ns_media_lang_en = $lang->getFormattedNsText(NS_MEDIA);
-          	$ns_file_lang_en  = $lang->getFormattedNsText(NS_FILE);
-          	$filename=preg_replace("/^($ns_media_wiki_lang|$ns_file_wiki_lang|$ns_media_lang_en|$ns_file_lang_en):/", '', $filename);
-        	} else {
-         		$filename=preg_replace("/^($ns_media_wiki_lang|$ns_file_wiki_lang):/", '', $filename);
-        	}
-				}
+        $mwServices = MediaWikiServices::getInstance();
+        if (method_exists($mwServices, "getContentLanguage")) {
+            $contentLang = $mwServices->getContentLanguage();
+            # there are four possible prefixes
+            $ns_media_wiki_lang = $contentLang->getFormattedNsText(NS_MEDIA);
+            $ns_file_wiki_lang  = $contentLang->getFormattedNsText(NS_FILE);
+            if (method_exists($mwServices, "getLanguageFactory")) {
+                $langFactory = $mwServices->getLanguageFactory();
+                $lang = $langFactory->getLanguage('en');
+                $ns_media_lang_en = $lang->getFormattedNsText(NS_MEDIA);
+                $ns_file_lang_en  = $lang->getFormattedNsText(NS_FILE);
+                $filename = preg_replace("/^($ns_media_wiki_lang|$ns_file_wiki_lang|$ns_media_lang_en|$ns_file_lang_en):/", '', $filename);
+            } else {
+                $filename = preg_replace("/^($ns_media_wiki_lang|$ns_file_wiki_lang):/", '', $filename);
+            }
+        }
         return $filename;
     }
 
@@ -85,27 +88,31 @@ class PDFEmbed
      */
     static public function generateTag($obj, $args = [], Parser $parser, PPFrame $frame)
     {
-        global $wgPdfEmbed, $wgRequest, $wgUser, $wgPDF;
+        global $wgPdfEmbed, $wgRequest, $wgPDF;
         // disable the cache
         PDFEmbed::disableCache($parser);
 
         // grab the uri by parsing to html
         $html = $parser->recursiveTagParse($obj, $frame);
+
         // check the action which triggered us
         $requestAction = $wgRequest->getVal('action');
+
         // depending on the action get the responsible user
         if ($requestAction == 'edit' || $requestAction == 'submit') {
-            $user = $wgUser;
+            $user = RequestContext::getMain()->getUser();
         } else {
+            // https://www.mediawiki.org/wiki/Manual:UserFactory.php
             $revUserName = $parser->getRevisionUser();
-            $user = User::newFromName($revUserName);
+            $userFactory = MediaWikiServices::getInstance()->getUserFactory();
+            $user = $userFactory->newFromName($revUserName);
         }
 
         if ($user === false) {
             return self::error('embed_pdf_invalid_user');
         }
 
-        if (! $user->isAllowed('embed_pdf')) {
+        if (!MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')) {
             return self::error('embed_pdf_no_permission');
         }
 
@@ -126,28 +133,34 @@ class PDFEmbed
         } else {
             $widthStr = $wgPdfEmbed['width'];
         }
+
         if (array_key_exists('height', $args)) {
             $heightStr = $parser->recursiveTagParse($args['height'], $frame);
         } else {
             $heightStr = $wgPdfEmbed['height'];
         }
+
         if (array_key_exists('page', $args)) {
             $page = intval($parser->recursiveTagParse($args['page'], $frame));
         } else {
             $page = 1;
         }
-        if (! preg_match('~^\d+~', $widthStr)) {
+
+        if (!preg_match('~^\d+~', $widthStr)) {
             return self::error("embed_pdf_invalid_width", $widthStr);
-        } elseif (! preg_match('~^\d+~', $heightStr)) {
+        } elseif (!preg_match('~^\d+~', $heightStr)) {
             return self::error("embed_pdf_invalid_height", $heightStr);
         }
+
         $width = intVal($widthStr);
         $height = intVal($heightStr);
+
         if (array_key_exists('iframe', $args)) {
             $iframe = $parser->recursiveTagParse($args['iframe'], $frame);
         } else {
             $iframe = $wgPdfEmbed['iframe'];
         }
+
         # if there are no slashes in the name we assume this
         # might be a pointer to a file
         if (preg_match('~^([^\/]+\.pdf)(#[0-9]+)?$~', $html, $re)) {
@@ -156,8 +169,10 @@ class PDFEmbed
             if (count($re) == 3) {
                 $page = $re[2];
             }
+
             $filename = self::removeFilePrefix($filename);
-            $pdfFile = wfFindFile($filename);
+            $pdfFile = MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename);
+
             if ($pdfFile !== false) {
                 $url = $pdfFile->getFullUrl();
                 return self::embed($url, $width, $height, $page, $iframe);
@@ -167,40 +182,42 @@ class PDFEmbed
         } else {
             // parse the given url
             $domain = parse_url($html);
+
             // check that the parsing worked and retrieve a valid host
             // no relative urls are allowed ...
-            if ($domain === false || (! isset($domain['host']))) {
-                if (! isset($domain['host'])) {
+            if ($domain === false || (!isset($domain['host']))) {
+                if (!isset($domain['host'])) {
                     return self::error("embed_pdf_invalid_relative_domain", $html);
                 }
                 return self::error("embed_pdf_invalid_url", $html);
             }
 
-						if (isset($wgPDF)) {
+            if (isset($wgPDF)) {
 
-										foreach ($wgPDF['black'] as $x => $y) {
-												$wgPDF['black'][$x] = strtolower($y);
-										}
-										foreach ($wgPDF['white'] as $x => $y) {
-												$wgPDF['white'][$x] = strtolower($y);
-										}
-										$host = strtolower($domain['host']);
+                foreach ($wgPDF['black'] as $x => $y) {
+                    $wgPDF['black'][$x] = strtolower($y);
+                }
+                foreach ($wgPDF['white'] as $x => $y) {
+                    $wgPDF['white'][$x] = strtolower($y);
+                }
 
-										$whitelisted = false;
-										if (in_array($host, $wgPDF['white'])) {
-												$whitelisted = true;
-										}
+                $host = strtolower($domain['host']);
+                $whitelisted = false;
 
-										if ($wgPDF['white'] != array() && ! $whitelisted) {
-												return self::error("embed_pdf_domain_not_white", $host);
-										}
+                if (in_array($host, $wgPDF['white'])) {
+                    $whitelisted = true;
+                }
 
-										if (! $whitelisted) {
-												if (in_array($host, $wgPDF['black'])) {
-														return pdfError("embed_pdf_domain_black", $host);
-												}
-										}
-						}
+                if ($wgPDF['white'] != array() && !$whitelisted) {
+                    return self::error("embed_pdf_domain_not_white", $host);
+                }
+
+                if (!$whitelisted) {
+                    if (in_array($host, $wgPDF['black'])) {
+                        return self::error("embed_pdf_domain_black", $host);
+                    }
+                }
+            }
 
             # check that url is valid
             if (filter_var($html, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)) {
@@ -234,6 +251,7 @@ class PDFEmbed
         # check the embed mode and return a proper HTML element
         if ($iframe) {
             return Html::rawElement('iframe', [
+                'class' => 'pdf-embed',
                 'width' => $width,
                 'height' => $height,
                 'src' => $pdfSafeUrl,
@@ -242,33 +260,20 @@ class PDFEmbed
         } else {
             # object mode (default)
             return Html::rawElement('object', [
+                'class' => 'pdf-embed',
                 'width' => $width,
                 'height' => $height,
                 'data' => $pdfSafeUrl,
+                'style' => 'max-width: 100%;',
                 'type' => 'application/pdf'
-            ], Html::rawElement('a', [
-                'href' => $pdfSafeUrl
-            ], 'load PDF' // i18n?
+            ], Html::rawElement(
+                'a',
+                [
+                    'href' => $pdfSafeUrl
+                ],
+                'load PDF' // i18n?
             ));
         }
-    }
-
-    /**
-     * return a pdfObject with the given data, width and height
-     *
-     * @param
-     *            data - the data to convert to an object
-     * @param
-     *            width - the width in pixels
-     * @param
-     *            height - the height in pixels
-     */
-    static private function embedObject($data, $width, $height)
-    {
-        $html = '<object width="' . $width . '" height="' . $height . '" data="' . htmlentities($data) . '" type="application/pdf">' . "\n";
-        $html .= '<a href="' . htmlentities($data) . '">load PDF</a>' . "\n";
-        $html .= '</object>' . "\n";
-        return $html;
     }
 
     /**

--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -11,6 +11,8 @@
  *
  **/
 
+use MediaWiki\MediaWikiServices;
+
 class PDFEmbed
 {
 
@@ -51,7 +53,7 @@ class PDFEmbed
      */
     static public function removeFilePrefix($filename)
     {
-        $mwServices = MediaWiki\MediaWikiServices::getInstance();
+        $mwServices = MediaWikiServices::getInstance();
         if (method_exists($mwServices, "getContentLanguage")) {
             $contentLang = $mwServices->getContentLanguage();
             # there are four possible prefixes
@@ -102,7 +104,7 @@ class PDFEmbed
         } else {
             // https://www.mediawiki.org/wiki/Manual:UserFactory.php
             $revUserName = $parser->getRevisionUser();
-            $userFactory = MediaWiki\MediaWikiServices::getInstance()->getUserFactory();
+            $userFactory = MediaWikiServices::getInstance()->getUserFactory();
             $user = $userFactory->newFromName($revUserName);
         }
 
@@ -110,7 +112,7 @@ class PDFEmbed
             return self::error('embed_pdf_invalid_user');
         }
 
-        if (!MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')) {
+        if (!MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')) {
             return self::error('embed_pdf_no_permission');
         }
 
@@ -169,7 +171,7 @@ class PDFEmbed
             }
 
             $filename = self::removeFilePrefix($filename);
-            $pdfFile = MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename);
+            $pdfFile = MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename);
 
             if ($pdfFile !== false) {
                 $url = $pdfFile->getFullUrl();

--- a/extension.json
+++ b/extension.json
@@ -12,7 +12,7 @@
 	"descriptionmsg": "pdfembed_description",
 	"license-name": "LGPL-3.0-only",
 	"requires": {
-		"MediaWiki": ">= 1.38.0"
+		"MediaWiki": ">= 1.29.0"
 	},
 	"type": "parserhook",
 	"GroupPermissions": {

--- a/extension.json
+++ b/extension.json
@@ -1,17 +1,18 @@
 {
 	"name": "PDFEmbed",
-	"version": "2.0.5",
+	"version": "3.0.0",
 	"author": [
-        "[https://www.mediawiki.org/wiki/User:Alexia_E._Smith Alexia E. Smith]",
-        "[http://www.bitplan.com/index.php/Wolfgang_Fahl Wolfgang Fahl/ProfiWiki]",
-        "[http://hexmode.com Mark A. Hershberger]",
-        "[https://clkoerner.com Chris Koerner]"
-    ],
+		"[https://www.mediawiki.org/wiki/User:Alexia_E._Smith Alexia E. Smith]",
+		"[http://www.bitplan.com/index.php/Wolfgang_Fahl Wolfgang Fahl/ProfiWiki]",
+		"[http://hexmode.com Mark A. Hershberger]",
+		"[https://clkoerner.com Chris Koerner]",
+		"[https://github.com/metalevel-tech Spas Z. Spasov]"
+	],
 	"url": "https://www.mediawiki.org/wiki/Extension:PDFEmbed",
 	"descriptionmsg": "pdfembed_description",
 	"license-name": "LGPL-3.0-only",
 	"requires": {
-		"MediaWiki": ">= 1.29.0"
+		"MediaWiki": ">= 1.38.0"
 	},
 	"type": "parserhook",
 	"GroupPermissions": {
@@ -41,7 +42,7 @@
 		"PdfEmbed": {
 			"width": 800,
 			"height": 1090,
-      "iframe": false
+			"iframe": false
 		}
 	},
 	"manifest_version": 1

--- a/extension.json
+++ b/extension.json
@@ -42,7 +42,7 @@
 		"PdfEmbed": {
 			"width": 800,
 			"height": 1090,
-			"iframe": false
+			"iframe": true
 		}
 	},
 	"manifest_version": 1

--- a/extension.json
+++ b/extension.json
@@ -1,17 +1,18 @@
 {
 	"name": "PDFEmbed",
-	"version": "2.0.5",
+	"version": "3.0.0",
 	"author": [
-        "[https://www.mediawiki.org/wiki/User:Alexia_E._Smith Alexia E. Smith]",
-        "[http://www.bitplan.com/index.php/Wolfgang_Fahl Wolfgang Fahl/ProfiWiki]",
-        "[http://hexmode.com Mark A. Hershberger]",
-        "[https://clkoerner.com Chris Koerner]"
-    ],
+		"[https://www.mediawiki.org/wiki/User:Alexia_E._Smith Alexia E. Smith]",
+		"[http://www.bitplan.com/index.php/Wolfgang_Fahl Wolfgang Fahl/ProfiWiki]",
+		"[http://hexmode.com Mark A. Hershberger]",
+		"[https://clkoerner.com Chris Koerner]",
+		"[https://github.com/metalevel-tech Spas Z. Spasov]"
+	],
 	"url": "https://www.mediawiki.org/wiki/Extension:PDFEmbed",
 	"descriptionmsg": "pdfembed_description",
 	"license-name": "LGPL-3.0-only",
 	"requires": {
-		"MediaWiki": ">= 1.29.0"
+		"MediaWiki": ">= 1.38.0"
 	},
 	"type": "parserhook",
 	"GroupPermissions": {
@@ -41,7 +42,7 @@
 		"PdfEmbed": {
 			"width": 800,
 			"height": 1090,
-      "iframe": false
+			"iframe": true
 		}
 	},
 	"manifest_version": 1

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Spas.Z.Spasov"
+		]
+	},
+	"pdfembed": "Вграждане на PDF файлове",
+	"pdfembed_description": "Разширение за обработване на PDF файлове.",
+	"embed_pdf_invalid_height": "Невалиден параметър за височина (height) $1.",
+	"embed_pdf_invalid_width": " Невалиден параметър за широчина (width) $1.",
+	"embed_pdf_no_permission": "Нямате права за вграждане на PDF файлове.",
+	"embed_pdf_blank_file": "Адресът (URL) или пътят на PDF файла за вграждане не е зададен.",
+	"embed_pdf_invalid_file": "Адресът (URL) на файла $1 не съществува.",
+	"embed_pdf_invalid_user": "Посочен е невалиден потребител за тестване на разширението за вграждане на PDF файлове.",
+	"right-embed_pdf": "Вграждане на PDF файлове в страници"
+}


### PR DESCRIPTION
Make it fully compatible with MediaWiki 1.38. Deal with all deprecated features:
* Use [`$wgOut->disableClientCache()`](https://doc.wikimedia.org/mediawiki-core/master/php/classOutputPage.html#a65494796ef2a9e3cb0864d8c2185fa70) instead of [`$wgOut->enableClientCache(false)`](https://doc.wikimedia.org/mediawiki-core/master/php/classOutputPage.html#a97ca228e1106736ef2b3b988543af448),
* Use `RequestContext::getMain()->getUser()` instead of `$wgUser`,
* Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
* Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
* Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
  
Tidy up the code, and:
* Remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`,
* Replace some short names: `$a` with `$anchor`; `$re` with `$matches`.

According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.

Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.

Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@metalevel.tech>

Add backwards compatibility. Already tested with MediaWiki versions [1.35](https://bg.trivictoria.org/wiki/Test_PDF_Embed), [1.36](https://vectoria.altclavis.com/wiki/Test_PDF_Embed), [1.38](https://wiki.metalevel.tech/wiki/Embed_PDF_Documents).