### PR TITLE
Do not provide an empty array as the default value

### DIFF
--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -94,7 +94,7 @@ class PDFEmbed
      *            object PPFrame object.
      * @return string HTML
      */
-    static public function generateTag($obj, $args = [], Parser $parser, PPFrame $frame)
+    static public function generateTag($obj, $args = [], ?Parser $parser, ?PPFrame $frame)
     {
         global $wgPdfEmbed, $wgRequest, $wgPDF;
         // disable the cache


### PR DESCRIPTION
This keeps the deprecation notice

    Optional parameter $args declared before required parameter $frame is implicitly treated as a required parameter

from appearing.

Fixes #19